### PR TITLE
Se corrige falla que impedia generar un XML de un comprobante generad…

### DIFF
--- a/ClaseCertificadoSellos.pas
+++ b/ClaseCertificadoSellos.pas
@@ -170,6 +170,9 @@ begin
   Assert(fx509Certificado <> nil, 'El certificado interno X509 fue nulo');
 
   sCertificadoBase64 := fx509Certificado.AsBase64;
+  Assert(Pos(_CADENA_INICIO_CERTIFICADO, sCertificadoBase64) > 0, 'No se tuvo cadena de inicio de certificado');
+  Assert(Pos(_CADENA_FIN_CERTIFICADO, sCertificadoBase64) > 0, 'No se tuvo cadena de fin de certificado');
+
   // Quita los encabezados, pie y retornos de carro del certificado
   sCertificadoBase64:=StringReplace(sCertificadoBase64, #13, '', [rfReplaceAll, rfIgnoreCase]);
   sCertificadoBase64:=StringReplace(sCertificadoBase64, #10, '', [rfReplaceAll, rfIgnoreCase]);

--- a/OpenSSLUtils.pas
+++ b/OpenSSLUtils.pas
@@ -482,7 +482,7 @@ end;
 function TX509Certificate.AsBase64() : String;
 var
   bioOut: pBIO;
-  Buffer: array [0..2048] of Caracter;
+  Buffer: array [0..4096] of Caracter;
   Res: String;
 begin
   // This code was translated from x509.c from the OpenSSL source code


### PR DESCRIPTION
…o con un certificado de 2048 bits debido a que el buffer no era lo suficientemente grande como para almacenarlo regresando caracteres invalidos.