### PR TITLE
Bugfix Cantidad de decimales en XML

### DIFF
--- a/ComprobanteFiscal.pas
+++ b/ComprobanteFiscal.pas
@@ -167,7 +167,7 @@ type
     ///	  Version del comprobante a crear
     ///	</param>
     {$ENDREGION}
-    constructor Create(const aVersionComprobante: TFEVersionComprobante = fev32; RecalcularImporte: Boolean = True);
+    constructor Create(const aVersionComprobante: TFEVersionComprobante = fev32; aRecalcularImporte: Boolean = True);
     destructor Destroy(); override;
     procedure Cancelar();
 
@@ -222,9 +222,9 @@ uses FacturaReglamentacion, ClaseOpenSSL, StrUtils, SelloDigital,
 
 // Al crear el objeto, comenzamos a "llenar" el XML interno
 constructor TFEComprobanteFiscal.Create(const aVersionComprobante:
-    TFEVersionComprobante = fev32; RecalcularImporte: Boolean = True);
+    TFEVersionComprobante = fev32; aRecalcularImporte: Boolean = True);
 begin
-  inherited Create(RecalcularImporte);
+  inherited Create(aRecalcularImporte);
   _CADENA_PAGO_UNA_EXHIBICION := 'Pago en una sola exhibición';
   _CADENA_PAGO_PARCIALIDADES := 'En parcialidades';
 
@@ -233,7 +233,7 @@ begin
   {$ENDIF}
 
   // Almacenamos si queremos recalcular el Importe
-  fRecalcularImporte := RecalcularImporte;
+  fRecalcularImporte := aRecalcularImporte;
 
    // Ahora La decisión de que tipo de comprobante y su versión deberá de ser del programa y no de la clase
   fVersion:=aVersionComprobante;

--- a/ComprobanteFiscal.pas
+++ b/ComprobanteFiscal.pas
@@ -78,6 +78,7 @@ type
     fAutoAsignarFechaGeneracion: Boolean;
     FValidarCertificadoYLlavePrivada: Boolean;
     FVerificarRFCDelCertificado: Boolean;
+    fRecalcularImporte  : Boolean;
 
 
     {$REGION 'Documentation'}
@@ -166,7 +167,7 @@ type
     ///	  Version del comprobante a crear
     ///	</param>
     {$ENDREGION}
-    constructor Create(const aVersionComprobante: TFEVersionComprobante = fev32);
+    constructor Create(const aVersionComprobante: TFEVersionComprobante = fev32; RecalcularImporte: Boolean = True);
     destructor Destroy(); override;
     procedure Cancelar();
 
@@ -221,15 +222,18 @@ uses FacturaReglamentacion, ClaseOpenSSL, StrUtils, SelloDigital,
 
 // Al crear el objeto, comenzamos a "llenar" el XML interno
 constructor TFEComprobanteFiscal.Create(const aVersionComprobante:
-    TFEVersionComprobante = fev32);
+    TFEVersionComprobante = fev32; RecalcularImporte: Boolean = True);
 begin
-  inherited Create;
+  inherited Create(RecalcularImporte);
   _CADENA_PAGO_UNA_EXHIBICION := 'Pago en una sola exhibición';
   _CADENA_PAGO_PARCIALIDADES := 'En parcialidades';
 
   {$IFDEF VERSION_DE_PRUEBA}
     _USAR_HORA_REAL := False;
   {$ENDIF}
+
+  // Almacenamos si queremos recalcular el Importe
+  fRecalcularImporte := RecalcularImporte;
 
    // Ahora La decisión de que tipo de comprobante y su versión deberá de ser del programa y no de la clase
   fVersion:=aVersionComprobante;
@@ -646,7 +650,11 @@ begin
 
         Descripcion := TFEReglamentacion.ComoCadena(Concepto.Descripcion);
         ValorUnitario := TFEReglamentacion.ComoMoneda(Concepto.ValorUnitario);
-        Importe := TFEReglamentacion.ComoMoneda(Concepto.ValorUnitario * Concepto.Cantidad);
+
+        //  Si esta habilitada la bandera permite recalcular el importe u obtenerlo directamente de la variable
+        if fRecalcularImporte
+        then Importe := TFEReglamentacion.ComoMoneda(Concepto.ValorUnitario * Concepto.Cantidad)
+        else Importe := TFEReglamentacion.ComoMoneda(Concepto.Importe);
 
         // Le fue asignada informacion aduanera??
         if (Concepto.DatosAduana.NumeroDocumento <> '') then

--- a/DocComprobanteFiscal.pas
+++ b/DocComprobanteFiscal.pas
@@ -207,7 +207,7 @@ end;
 
 function TDocumentoComprobanteFiscal.ObtenerImporte(Concepto: TFEConcepto) : Currency;
 begin
-    Result:=Concepto.ValorUnitario * Concepto.Cantidad;
+    Result:= Concepto.Importe;
 end;
 
 end.

--- a/DocComprobanteFiscal.pas
+++ b/DocComprobanteFiscal.pas
@@ -60,7 +60,7 @@ RAZON PARA CAMBIAR:
         function obtenerNumArticulos() : Integer;
         function getTotal() : Currency;
     public
-        constructor Create(RecalcularImporte : Boolean); overload;
+        constructor Create(aRecalcularImporte : Boolean = True); overload;
         // Propiedades del comprobante normal
         property FacturaGenerada: Boolean read fFacturaGenerada write fFacturaGenerada;
         property Serie: TFESerie read fSerie write fSerie;
@@ -120,7 +120,7 @@ implementation
 
 uses SysUtils;
 
-constructor TDocumentoComprobanteFiscal.Create(RecalcularImporte : Boolean = True);
+constructor TDocumentoComprobanteFiscal.Create(aRecalcularImporte : Boolean = True);
 begin
     // TODO LO SIGUIENTE LO HACE DELPHI POR NOSOTROS:
     // Rewrite:
@@ -132,7 +132,7 @@ begin
     bHuboRetenciones:=False;
     bHuboTraslados:=False; }
   inherited Create;
-  fRecalcularImporte := RecalcularImporte;
+  fRecalcularImporte := aRecalcularImporte;
 end;
 
 function TDocumentoComprobanteFiscal.obtenerNumArticulos() : Integer;

--- a/DocComprobanteFiscal.pas
+++ b/DocComprobanteFiscal.pas
@@ -55,7 +55,7 @@ RAZON PARA CAMBIAR:
         FNumeroDeCuenta: String;
 
         // Funcion usada para obtener el importe de un concepto 
-        function ObtenerImporte(Concepto: TFEConcepto) : Currency;
+        function ObtenerImporte(Concepto: TFEConcepto; aEsImporteAsignadoManualmente: Boolean = False) : Currency;
         function obtenerNumArticulos() : Integer;
         function getTotal() : Currency;
     public
@@ -205,9 +205,13 @@ begin
                                      (fTotalImpuestosLocalesTrasladados - fTotalImpuestosLocalesRetenidos);
 end;
 
-function TDocumentoComprobanteFiscal.ObtenerImporte(Concepto: TFEConcepto) : Currency;
+function TDocumentoComprobanteFiscal.ObtenerImporte(Concepto: TFEConcepto;
+      aEsImporteAsignadoManualmente: Boolean = False) : Currency;
 begin
-    Result:= Concepto.Importe;
+  if aImporteAsignadoManualmente then
+      Result := Concepto.Importe
+  else
+      Result := Concepto.ValorUnitario * Concepto.Cantidad;
 end;
 
 end.

--- a/FacturaElectronica.pas
+++ b/FacturaElectronica.pas
@@ -40,6 +40,7 @@ TFacturaElectronica = class(TFEComprobanteFiscal)
   fComprobanteGenerado : Boolean;
   fOnComprobanteTimbrado : TOnComprobanteTimbrado;
   fOnComprobanteGenerado: TOnComprobanteGenerado;
+   fRecalcularImporte: Boolean;
   function GetonComprobanteTimbrado: TOnComprobanteTimbrado;
   function obtenerCertificado() : TFECertificado;
   procedure SetonComprobanteTimbrado(const Value: TOnComprobanteTimbrado);
@@ -65,7 +66,7 @@ public
   constructor Create(cEmisor, cCliente: TFEContribuyente; bfBloqueFolios: TFEBloqueFolios;
                      cerCertificado: TFECertificado; tcTipo: TFETipoComprobante);  overload; deprecated;
   constructor Create(cEmisor, cCliente: TFEContribuyente; cerCertificado: TFECertificado;
-                      tcTipo: TFETipoComprobante);  overload;
+                      tcTipo: TFETipoComprobante; aRecalcularImporte :Boolean = True);  overload;
 
   destructor Destroy; override;
   procedure AfterConstruction; override;
@@ -79,23 +80,23 @@ public
   procedure Guardar(const aArchivoDestino: String);
   procedure AsignarTimbreFiscal(const aTimbre: TFETimbre); override;
 published
-  constructor Create; overload;
+  constructor Create(aRecalcularImporte :Boolean = True); overload;
 end;
 
 implementation
 
 uses sysutils, Classes;
 
-constructor TFacturaElectronica.Create;
+constructor TFacturaElectronica.Create(aRecalcularImporte :Boolean = True);
 begin
-  inherited Create;
+  inherited Create(fev32, aRecalcularImporte);
 end;
 
 constructor TFacturaElectronica.Create(cEmisor, cCliente: TFEContribuyente; cerCertificado: TFECertificado;
-                      tcTipo: TFETipoComprobante);
+                      tcTipo: TFETipoComprobante; aRecalcularImporte :Boolean = True);
 begin
   // Si usamos este constructor que no usa bloque de folios creamos un CFDI 3.2 por default
-  inherited Create(fev32);
+  inherited Create(fev32, aRecalcularImporte);
   // Llenamos las variables internas con las de los parametros
   inherited Emisor:=cEmisor;
   inherited Receptor:=cCliente;

--- a/FacturaReglamentacion.pas
+++ b/FacturaReglamentacion.pas
@@ -27,16 +27,16 @@ type
       /// <summary>Convierte el valor de moneda al formato de dinero requerido por el SAT
       /// </summary>
       /// <param name="Monto">Monto a convertir al formato aceptado por el SAT</param>
-      class function ComoMoneda(aMonto: Currency; const aDecimalesDefault: Integer =
-          6): String;
+      class function ComoMoneda(aMonto: Currency; const aDecimalesDefault: Integer
+          = 2): String;
       class function ComoCadena(sCadena: String) : String;
       class function ComoCantidad(dCantidad: Double; const aNumeroDecimales: Integer
-          = 6): String;
+          = 2): String;
       class function ComoFechaHora(dtFecha: TDateTime) : String;
       class function DeFechaHoraISO8601(const aFechaISO8601: String) : TDateTime;
       class function ComoFechaAduanera(dtFecha: TDateTime) : String;
       class function ComoTasaImpuesto(dTasa: Double; const aDecimalesDefault: Integer
-          = 6): String;
+          = 2): String;
       class function ComoDateTime(sFechaISO8601: String): TDateTime;
       class function ComoFechaHoraInforme(dtFecha: TDateTime) : String;
       class function DeTasaImpuesto(const aCadenaTasa: String) : Double;
@@ -130,7 +130,7 @@ begin
 end;
 
 class function TFEReglamentacion.ComoMoneda(aMonto: Currency; const
-    aDecimalesDefault: Integer = 6): String;
+    aDecimalesDefault: Integer = 2): String;
 begin
    // Regresamos los montos de monedas con 6 decimales (maximo permitido en el XSD)
    // http://www.sat.gob.mx/cfd/3/cfdv32.xsd
@@ -144,7 +144,7 @@ begin
 end;
 
 class function TFEReglamentacion.ComoTasaImpuesto(dTasa: Double; const
-    aDecimalesDefault: Integer = 6): String;
+    aDecimalesDefault: Integer = 2): String;
 begin
    // Regresamos los montos de monedas con 6 decimales (maximo permitido en el XSD)
    // http://www.sat.gob.mx/cfd/3/cfdv32.xsd
@@ -208,7 +208,7 @@ begin
 end;
 
 class function TFEReglamentacion.ComoCantidad(dCantidad: Double; const
-    aNumeroDecimales: Integer = 6): String;
+    aNumeroDecimales: Integer = 2): String;
 begin
    // Las cantidades cerradas las regresamos sin decimales
    // las que tienen fracciones con 6 digitos decimales para respetar la especificacion


### PR DESCRIPTION
- Además se usa como base de los conceptos el importe en vez del valor unitario * cantidad
- Se queda en dos decimales para el total, subtotal y cantidades

[#106710118]