### PR TITLE
Excepciones relacionadas con IVA de Franja Fronteriza y otros

### DIFF
--- a/Facturacion.Tipos.pas
+++ b/Facturacion.Tipos.pas
@@ -38,8 +38,7 @@ type
   private
     fCodigoError: Integer;
   public
-    constructor Create(const aMensajeExcepcion: String;
-      const aCodigoError: Integer; const aReintentable: Boolean);
+    constructor Create(const aMensajeExcepcion: String; const aCodigoError: Integer; const aReintentable: Boolean);
     property CodigoError: Integer read fCodigoError;
   end;
 
@@ -53,22 +52,25 @@ type
   // Los errores técnicos, donde se omiten nodos, no coincide, etc. no se calculó bien, etc
   // serán heredados de la siguiente excepcion. Estos errores deberán ser corregidos
   // en la librería directamente
-  ESATErrorTecnicoXMLException            = class(ESATErrorGenericoException);
+  ESATErrorTecnicoXMLException                    = class(ESATErrorGenericoException);
   // Error en el certificado, probablemente certificado caduco
-  ESATErrorEnCertificadoException         = class(ESATErrorGenericoException);
+  ESATErrorEnCertificadoException                 = class(ESATErrorGenericoException);
   // Los errores de "configuracion" donde algun dato del emisor está mal segun el SAT
-  ESATDatoEmisorIncorrectoException       = class(ESATErrorGenericoException);
-  ESATDatoReceptorIncorrectoException     = class(ESATErrorGenericoException);
+  ESATDatoEmisorIncorrectoException               = class(ESATErrorGenericoException);
+  ESATDatoReceptorIncorrectoException             = class(ESATErrorGenericoException);
   // El porcentaje del impuesto tiene un valor fuera del catalogo de tasas c_TasaOCuota.json
-  ESAImpuestoTasaIncorrectaException      = class(ESATErrorGenericoException);
+  ESAImpuestoTasaIncorrectaException              = class(ESATErrorGenericoException);
   // Cuando algun valor de un campo de catalogo no existió en el mismo
-  ESATValorNoEnCatalogoException          = class(ESATErrorGenericoException);
+  ESATValorNoEnCatalogoException                  = class(ESATErrorGenericoException);
   // El uso de cfdi no es valido para el receptor
-  EUsoCFDIIncorrectoException             = class(ESATErrorGenericoException);
+  EUsoCFDIIncorrectoException                     = class(ESATErrorGenericoException);
   // Existió un error arimético en el XML
-  ESATProblemaDeLlenadoException          = class(ESATErrorGenericoException);
-  ESATCampoConfirmacionRequeridoException = class(ESATErrorGenericoException);
-  ESATNoIdentificadoException             = class(ESATErrorGenericoException); // CFDI33196
+  ESATProblemaDeLlenadoException                  = class(ESATErrorGenericoException);
+  ESATCampoConfirmacionRequeridoException         = class(ESATErrorGenericoException);
+  ESATNoIdentificadoException                     = class(ESATErrorGenericoException); // CFDI33196
+  ESATRFCNoPerteneceFronteraException             = class(ESATErrorGenericoException); // CFDI33196
+  ESATCodigoPostalNoPerteneceFronteraException    = class(ESATErrorGenericoException); // CFDI33196
+  ESATEstimuloFronteraNoAplicaAlProductoException = class(ESATErrorGenericoException); // CFDI33196
   {$IFDEF undef}{$ENDREGION}{$ENDIF}
 
 const

--- a/PACs/Ecodex/Facturacion.PAC.Ecodex.pas
+++ b/PACs/Ecodex/Facturacion.PAC.Ecodex.pas
@@ -217,6 +217,7 @@ var
   mensajeExcepcion: string;
   numeroErrorSAT: Integer;
 const
+  _ERROR_RFC_FRANJA_FRONTERIZA           = 'CFDI33196 El RFC no se encuentra registrado para aplicar el Est';
   _ERROR_CODIGO_POSTAL_FRANJA_FRONTERIZA = 'postal no corresponde a Franja Fronteriza.';
   _ERROR_CLAVE_PROD_FRANJA_FRONTERIZA    = 'Franja Fronteriza para la clave de producto o servicio';
 begin
@@ -282,7 +283,9 @@ begin
         // 3. El código postal no corresponde a Franja Fronteriza.
         33196:
         begin
-          if mensajeExcepcion.Contains(_ERROR_CODIGO_POSTAL_FRANJA_FRONTERIZA) then
+          if mensajeExcepcion.Contains(_ERROR_RFC_FRANJA_FRONTERIZA) then
+            raise ESATRFCNoPerteneceFronteraException.Create(mensajeExcepcion, numeroErrorSAT, False)
+          else if mensajeExcepcion.Contains(_ERROR_CODIGO_POSTAL_FRANJA_FRONTERIZA) then
             raise ESATCodigoPostalNoPerteneceFronteraException.Create(mensajeExcepcion, numeroErrorSAT, False)
           else if mensajeExcepcion.Contains(_ERROR_CLAVE_PROD_FRANJA_FRONTERIZA) then
             raise ESATEstimuloFronteraNoAplicaAlProductoException.Create(mensajeExcepcion, numeroErrorSAT, False)

--- a/PACs/Ecodex/Facturacion.PAC.Ecodex.pas
+++ b/PACs/Ecodex/Facturacion.PAC.Ecodex.pas
@@ -216,6 +216,8 @@ procedure TProveedorEcodex.ProcesarExcepcionDePAC(const aExcepcion: Exception);
 var
   mensajeExcepcion: string;
   numeroErrorSAT: Integer;
+const
+  _ERROR_CODIGO_POSTAL_FRANJA_FRONTERIZA = 'postal no corresponde a Franja Fronteriza.';
 begin
   mensajeExcepcion := aExcepcion.Message;
 
@@ -273,9 +275,17 @@ begin
           raise ESATProblemaDeLlenadoException.Create(mensajeExcepcion,
             numeroErrorSAT, False);
 
+        // Errores posibles con el mismo codigo:
+        // 1. El RFC no se encuentra registrado para aplicar el Estímulo Franja Fronteriza.
+        // 2. No aplica Estímulo Franja Fronteriza para la clave de producto o servicio
+        // 3. El código postal no corresponde a Franja Fronteriza.
         33196:
-          raise ESATNoIdentificadoException.Create(mensajeExcepcion,
-            numeroErrorSAT, False);
+        begin
+          if mensajeExcepcion.Contains(_ERROR_CODIGO_POSTAL_FRANJA_FRONTERIZA) then
+            raise ESATCodigoPostalNoPerteneceFronteraException.Create(mensajeExcepcion, numeroErrorSAT, False)
+          else
+            raise ESATNoIdentificadoException.Create(mensajeExcepcion, numeroErrorSAT, False);
+        end
       else
         raise ESATErrorGenericoException.Create('ESATErrorGenericoException (' +
           IntToStr(EEcodexFallaValidacionException(aExcepcion).Numero) + ') ' +

--- a/PACs/Ecodex/Facturacion.PAC.Ecodex.pas
+++ b/PACs/Ecodex/Facturacion.PAC.Ecodex.pas
@@ -218,6 +218,7 @@ var
   numeroErrorSAT: Integer;
 const
   _ERROR_CODIGO_POSTAL_FRANJA_FRONTERIZA = 'postal no corresponde a Franja Fronteriza.';
+  _ERROR_CLAVE_PROD_FRANJA_FRONTERIZA    = 'Franja Fronteriza para la clave de producto o servicio';
 begin
   mensajeExcepcion := aExcepcion.Message;
 
@@ -283,6 +284,8 @@ begin
         begin
           if mensajeExcepcion.Contains(_ERROR_CODIGO_POSTAL_FRANJA_FRONTERIZA) then
             raise ESATCodigoPostalNoPerteneceFronteraException.Create(mensajeExcepcion, numeroErrorSAT, False)
+          else if mensajeExcepcion.Contains(_ERROR_CLAVE_PROD_FRANJA_FRONTERIZA) then
+            raise ESATEstimuloFronteraNoAplicaAlProductoException.Create(mensajeExcepcion, numeroErrorSAT, False)
           else
             raise ESATNoIdentificadoException.Create(mensajeExcepcion, numeroErrorSAT, False);
         end

--- a/Versiones/Facturacion.ComplementoPagoV1.pas
+++ b/Versiones/Facturacion.ComplementoPagoV1.pas
@@ -504,10 +504,15 @@ end;
 { TPagos_PagoV1 }
 
 procedure TPagos_PagoV1.AfterConstruction;
+var
+  ItemTag : String;
 begin
   RegisterChildNode('DoctoRelacionado', TPagos_Pago_DoctoRelacionadoV1, TargetNamespace);
   RegisterChildNode('Impuestos', TPagos_Pago_ImpuestosV1);
-  FDoctoRelacionado := CreateCollection(TPagos_Pago_DoctoRelacionadoListV1, IPagos_Pago_DoctoRelacionadoV1, 'DoctoRelacionado') as IPagos_Pago_DoctoRelacionadoListV1;
+  ItemTag := 'Pago10:DoctoRelacionado';
+  FDoctoRelacionado := CreateCollection(TPagos_Pago_DoctoRelacionadoListV1,
+                                        IPagos_Pago_DoctoRelacionadoV1,
+                                        ItemTag) as IPagos_Pago_DoctoRelacionadoListV1;
   FImpuestos := CreateCollection(TPagos_Pago_ImpuestosListV1, IPagos_Pago_ImpuestosV1, 'Impuestos') as IPagos_Pago_ImpuestosListV1;
   inherited;
 end;


### PR DESCRIPTION
* Se agrega manejo de namespace de `DoctoRelacionado` para que sea el correcto `Pagos10:DoctoRelacionado` y no se tengan problemas con validador.
* Se manejan excepciones especificas de errores de timbrado con el proveedor Ecodex cuando el documento no pueda ser timbrado por causas atribuibles a Franja Fronteriza.