### PR TITLE
Eliminar directiva ELEVENTA

### DIFF
--- a/PACs/Ecodex/Facturacion.PAC.Ecodex.pas
+++ b/PACs/Ecodex/Facturacion.PAC.Ecodex.pas
@@ -120,9 +120,9 @@ begin
   // Ref: https://stackoverflow.com/questions/59666531/how-to-get-at-response-headers-from-thttpreqresp
   // NOTA: Solo funciona Delphi 10.3 o mayores
   {$IF Compilerversion >= 23}
-    {$IFNDEF ELEVENTA}
+    //{$IFNDEF ELEVENTA}
       SetOnHttpError(ManejarHttpSoapError);
-    {$ENDIF}
+    //{$ENDIF}
   {$IFEND}
 end;
 


### PR DESCRIPTION
### Resumen del problema
eleventa no esta procesando los errores SOAP que regresa el WS de Ecodex.

**URL Basecamp:**
https://

### Diagnóstico
* El manejador no se esta ejecutando porque el Setter se encontraba dentro de una condicional de directiva ELEVENTA.

### Cambios propuesto
- +Se elimina condicional con directiva ELEVENTA, ya que las configuraciones de Release, Beta, Soporte, etc las manejan.

### Checklist

* [ ] Ya hice mi propio Code Review.
* [ ] QA personal: Ya probé yo mismo que el fix funciona con el escenario descrito por Soporte Avanzado.
* [ ] MultiCaja : Se corroboró que funcione y compile bien en esta edición.
* [ ] Internacionales: Corroboré que funciones con simbolo de moneda distinto y con separador de miles de punto (Colombia, etc)
* [ ] QA Manual: Ya fue revisado y aprobado.

@lcarrasco CR por favor.
